### PR TITLE
fix: make the example in readme copy-pasteable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ your routes and endpoints.
 Example:
 
 ```javascript
+import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
+import { CoralogixTransactionSampler } from '@coralogix/opentelemetry';
+import { Resource } from "@opentelemetry/resources";
+import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+
 const sampler = new CoralogixTransactionSampler();
 
 const tracerProvider = new BasicTracerProvider({
@@ -16,8 +21,10 @@ const tracerProvider = new BasicTracerProvider({
     }),
     sampler
 });
+
 import express from "express";
-import router from "./router";
+
+const router = express.Router()
 
 const app = express();
 app.use('/', router);
@@ -27,3 +34,4 @@ sampler.setExpressApp(app);
 app.listen(3000, () => {
     console.log('Server is running')
 });
+```


### PR DESCRIPTION
It's still incomplete and doesn't explain why `tracerProvider` is not used, but at least it works.

Fixes #22 