### PR TITLE
fix(sampler): support Express 5 / NestJS 11 in setExpressApp (CDS-3047)

### DIFF
--- a/src/trace/samplers/coralogix-transaction-sampler.ts
+++ b/src/trace/samplers/coralogix-transaction-sampler.ts
@@ -7,13 +7,14 @@ import {ILayer} from "express-serve-static-core";
 import {SEMATTRS_HTTP_TARGET} from "@opentelemetry/semantic-conventions";
 
 export interface RouteMapping {
-    regex: RegExp,
+    matches: (path: string) => boolean,
     path: string,
 }
 
 interface Stack {
     route: { path: string },
-    regexp: RegExp
+    regexp?: RegExp,
+    match?: (path: string) => boolean,
 }
 
 interface Handle {
@@ -24,6 +25,10 @@ interface Handle {
 interface Handler {
     handle: Handle,
     name?: string,
+}
+
+interface RouterLike {
+    stack: (Handler | ILayer)[],
 }
 
 export class CoralogixTransactionSampler implements Sampler {
@@ -43,7 +48,15 @@ export class CoralogixTransactionSampler implements Sampler {
 
 
     private _getPathFromRoutes(path: string): string | undefined {
-        return this.routes.find(route => route.regex.test(path))?.path;
+        const pathname = path.replace(/[?#].*$/, '');
+        return this.routes.find(route => route.matches(pathname))?.path;
+    }
+
+    // Express 4 layers have `regexp`; Express 5 (router@2.x) replaced it with `match(path)`.
+    private _buildMatcher(layer: { regexp?: RegExp, match?: (path: string) => boolean }): (path: string) => boolean {
+        if (layer.regexp) return (p) => layer.regexp!.test(p);
+        if (layer.match) return layer.match.bind(layer);
+        return () => false;
     }
 
     private _buildTransactionNameFromExpressPath(path: string, spanName: string): string {
@@ -61,13 +74,21 @@ export class CoralogixTransactionSampler implements Sampler {
     setExpressApp(app: express.Application): void {
         const routes: RouteMapping[] = [];
 
-        app._router.stack.forEach((middleware: Handler | ILayer) => {
+        // @types/express v4 types app.router as a deprecated string; cast to reach both v4/v5 shapes.
+        const compat = app as unknown as { router?: RouterLike; _router?: RouterLike };
+        const expressRouter = compat.router ?? compat._router;
+        if (!expressRouter?.stack) {
+            diag.warn('CoralogixTransactionSampler.setExpressApp: could not find the Express router stack, route templates will not be resolved');
+            return;
+        }
+
+        expressRouter.stack.forEach((middleware: Handler | ILayer) => {
             if (this._isMiddlewareILayer(middleware)) {
                 // routes registered directly on the app
                 if (middleware.route?.path)
                     routes.push({
                         path: middleware.route.path,
-                        regex: middleware.regexp,
+                        matches: this._buildMatcher(middleware),
                     });
             } else if (this._isMiddlewareHandler(middleware)) {
                 // router middleware
@@ -78,7 +99,7 @@ export class CoralogixTransactionSampler implements Sampler {
                     if (route) {
                         routes.push({
                             path: route.path,
-                            regex: handler.regexp,
+                            matches: this._buildMatcher(handler),
                         });
                     }
                 });

--- a/test/trace/samplers/set-express-app.spec.ts
+++ b/test/trace/samplers/set-express-app.spec.ts
@@ -1,0 +1,71 @@
+import {describe, it} from "node:test";
+import assert from "node:assert";
+import {SpanKind, ROOT_CONTEXT} from "@opentelemetry/api";
+import {SEMATTRS_HTTP_TARGET} from "@opentelemetry/semantic-conventions";
+import {CoralogixTransactionSampler} from "../../../src/trace/samplers";
+import {CoralogixAttributes} from "../../../src/trace/common";
+
+const TRANSACTION = CoralogixAttributes.TRANSACTION_IDENTIFIER;
+
+function resolveTransaction(sampler: CoralogixTransactionSampler, target: string): unknown {
+    const result = sampler.shouldSample(ROOT_CONTEXT, 'trace-id', 'GET', SpanKind.SERVER, {
+        [SEMATTRS_HTTP_TARGET]: target,
+    }, []);
+    return result.attributes?.[TRANSACTION];
+}
+
+function express4App() {
+    const routeLayer = {
+        name: 'bound dispatch',
+        route: {path: '/users/:id'},
+        regexp: /^\/users\/(?:([^/]+?))\/?$/i,
+    };
+    return {_router: {stack: [routeLayer]}};
+}
+
+function express5App() {
+    const routeLayer = {
+        name: 'bound dispatch',
+        route: {path: '/users/:id'},
+        match(path: string): boolean {
+            return /^\/users\/[^/]+$/.test(path);
+        },
+    };
+    return {router: {stack: [routeLayer]}};
+}
+
+export default describe('CoralogixTransactionSampler#setExpressApp', () => {
+    it('resolves the route template on Express 4 (regression)', () => {
+        const sampler = new CoralogixTransactionSampler();
+        sampler.setExpressApp(express4App() as never);
+
+        assert.strictEqual(resolveTransaction(sampler, '/users/123'), 'GET /users/:id');
+    });
+
+    it('does not throw when Express 5 has no _router', () => {
+        const sampler = new CoralogixTransactionSampler();
+
+        assert.doesNotThrow(() => sampler.setExpressApp(express5App() as never));
+    });
+
+    it('resolves the route template on Express 5', () => {
+        const sampler = new CoralogixTransactionSampler();
+        sampler.setExpressApp(express5App() as never);
+
+        assert.strictEqual(resolveTransaction(sampler, '/users/123'), 'GET /users/:id');
+    });
+
+    it('resolves the route template when the target carries a query string', () => {
+        const sampler = new CoralogixTransactionSampler();
+        sampler.setExpressApp(express5App() as never);
+
+        assert.strictEqual(resolveTransaction(sampler, '/users/123?expand=true'), 'GET /users/:id');
+    });
+
+    it('falls back to the span name when no route matches', () => {
+        const sampler = new CoralogixTransactionSampler();
+        sampler.setExpressApp(express5App() as never);
+
+        assert.strictEqual(resolveTransaction(sampler, '/unknown/path'), 'GET');
+    });
+});


### PR DESCRIPTION
## Summary

- `setExpressApp` crashed on boot with Express 5 / NestJS 11 because `app._router` was removed; Express 5 exposes the router via the public `app.router` getter instead
- Even if the crash was worked around, `cx.transaction` would still collapse to the bare HTTP method because Express 5's router@2.x layers no longer carry a `regexp` property — it was replaced with a `match(path)` method (path-to-regexp v8)
- This fix resolves both issues while keeping Express 4 working

## Changes

- Fall back to `app.router` when `app._router` is absent (`router ?? _router`)
- Emit a `diag.warn` instead of throwing when no router stack is found (app boots safely)
- Introduce `_buildMatcher` to abstract over the Express 4 (`regexp`) vs Express 5 (`match`) layer shapes
- Replace `RouteMapping.regex: RegExp` with `matches: (path: string) => boolean`
- Strip query string and hash from `http.target` before matching (Express matchers only handle the pathname)
- Add synthetic-stack tests covering Express 4 and Express 5 layer shapes with query strings, no-match fallback, and boot safety

## Test plan

- [ ] `npm test` — 19 tests pass (14 existing + 5 new `setExpressApp` cases)
- [ ] Existing Express 4 route resolution still works (regression test included)
- [ ] Express 5 app boots without throwing `TypeError: Cannot read properties of undefined (reading 'stack')`
- [ ] `cx.transaction` resolves to the route template (`GET /users/:id`) instead of bare HTTP method on Express 5

