### PR TITLE
fix: bump version to 0.1.4 and guard publish workflows

### DIFF
--- a/.github/workflows/publish-jfrog.yml
+++ b/.github/workflows/publish-jfrog.yml
@@ -30,6 +30,16 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build
+      - name: Verify package version matches release tag
+        if: github.event_name == 'release'
+        run: |
+          TAG_VERSION="${{ github.event.release.tag_name }}"
+          TAG_VERSION="${TAG_VERSION#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "package.json version ($PKG_VERSION) does not match release tag (v$TAG_VERSION)"
+            exit 1
+          fi
       - run: npm prune dev
       - run: curl -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" https://cgx.jfrog.io/artifactory/api/npm/internal.npm.coralogix.net/auth/coralogix | tee ~/.npmrc
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,5 +30,15 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build
+      - name: Verify package version matches release tag
+        if: github.event_name == 'release'
+        run: |
+          TAG_VERSION="${{ github.event.release.tag_name }}"
+          TAG_VERSION="${TAG_VERSION#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "package.json version ($PKG_VERSION) does not match release tag (v$TAG_VERSION)"
+            exit 1
+          fi
       - run: npm prune dev
       - run: npm publish --access public

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coralogix/opentelemetry",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coralogix/opentelemetry",
-      "version": "0.1.2",
+      "version": "0.1.4",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/sdk-trace-base": "^1.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralogix/opentelemetry",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Bump `package.json` and `package-lock.json` to `0.1.4` to match the existing `v0.1.4` GitHub release (Express 5 / NestJS 11 support)
- Add a pre-publish check in both `publish.yml` and `publish-jfrog.yml` that fails when the release tag does not match `package.json` version

## Context
The `v0.1.4` release was created without updating `package.json` (still `0.1.3`). Both publish workflows attempted to republish `0.1.3`, which already exists on npm, causing the publish jobs to fail.

## Test plan
- [x] `npm ci && npm run build && npm test` pass locally
- [ ] Merge PR
- [ ] Re-run the **NPM publish** workflow (workflow_dispatch or re-create the `v0.1.4` release) after merge
- [ ] Confirm `@coralogix/opentelemetry@0.1.4` appears on npm
- [ ] Verify `NPM_TOKEN` has publish access to the `@coralogix` org if npm still returns 404


Made with [Cursor](https://cursor.com)