### PR TITLE
fix: restore NPM_TOKEN auth for npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/
+          scope: '@coralogix'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm ci
       - run: npm run build
       - name: Verify package version matches release tag
@@ -42,3 +45,5 @@ jobs:
           fi
       - run: npm prune dev
       - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Restore `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` on the publish job (removed in #28)
- Pass the token into `setup-node` so it does not export the dummy placeholder
- Add `scope: '@coralogix'` for correct scoped registry auth

## Root cause
[Run 28181098955](https://github.com/coralogix/coralogix-opentelemetry-js/actions/runs/28181098955) failed with:

```
npm error 404  '@coralogix/opentelemetry@0.1.4' is not in this registry.
```

The version bump fix worked (`0.1.4` was packaged correctly). Auth was the problem.

`actions/setup-node@v3` exports a **literal placeholder** when `NODE_AUTH_TOKEN` is unset:

```ts
core.exportVariable(
  'NODE_AUTH_TOKEN',
  process.env.NODE_AUTH_TOKEN || 'XXXXX-XXXXX-XXXXX-XXXXX'
);
```

That matches the masked value in the failed job logs — it was not a real npm token. #28 removed the mapping from `secrets.NPM_TOKEN`.

## Test plan
- [ ] Merge PR
- [ ] Confirm `NPM_TOKEN` secret exists in repo/org settings (token for `coralogixnpm` with publish access to `@coralogix`)
- [ ] Re-run **NPM publish** workflow (`workflow_dispatch`)
- [ ] Verify `@coralogix/opentelemetry@0.1.4` on npm


Made with [Cursor](https://cursor.com)