### PR TITLE
fix: enable npm trusted publishing (OIDC) in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,6 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+# Publish to npm using Trusted Publishing (OIDC).
+# Configure the trusted publisher on npmjs.com for workflow file: publish.yml
+# https://docs.npmjs.com/trusted-publishers/
 
 name: NPM publish
 
@@ -12,8 +13,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - run: npm ci
@@ -22,12 +23,16 @@ jobs:
   publish-npm:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
-          registry-url: https://registry.npmjs.org/
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          scope: '@coralogix'
       - run: npm ci
       - run: npm run build
       - name: Verify package version matches release tag
@@ -41,4 +46,7 @@ jobs:
             exit 1
           fi
       - run: npm prune dev
-      - run: npm publish --access public
+      - name: Publish to npm via OIDC
+        run: |
+          unset NODE_AUTH_TOKEN
+          npm publish --access public

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "files": [
     "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/coralogix/coralogix-opentelemetry-js.git"
+  },
   "scripts": {
     "test": "tsc && npm run lint && npm run test:unit",
     "test:unit": "node --import tsx --test test/test.ts",


### PR DESCRIPTION
## Summary
- Add `permissions: id-token: write` required for npm Trusted Publishing (OIDC)
- Use Node 24 on the publish job (npm ≥ 11.5.1 required for OIDC)
- Upgrade `actions/checkout` and `actions/setup-node` to v4
- Unset `NODE_AUTH_TOKEN` before publish so `setup-node`'s placeholder token does not override OIDC
- Add `repository` to `package.json` (npm validates this against the GitHub trusted publisher)

## Context
#28 correctly removed `NPM_TOKEN` for OIDC, but the workflow was still missing the pieces npm/GitHub require for trusted publishing. [Run 28181098955](https://github.com/coralogix/coralogix-opentelemetry-js/actions/runs/28181098955) failed with E404 while publishing `0.1.4` — the version was correct; auth was not.

Replaces #30 (token-based fix), which is not the intended direction.

## npm trusted publisher checklist
Confirm on [npm package settings](https://www.npmjs.com/package/@coralogix/opentelemetry) → **Trusted Publisher**:
- [ ] Provider: **GitHub Actions**
- [ ] Organization: `coralogix`
- [ ] Repository: `coralogix-opentelemetry-js`
- [ ] Workflow filename: `publish.yml` (exact, case-sensitive)

## Test plan
- [ ] Merge PR
- [ ] Re-run **NPM publish** (`workflow_dispatch`)
- [ ] Confirm `@coralogix/opentelemetry@0.1.4` on npm


Made with [Cursor](https://cursor.com)