### PR TITLE
fix(deps)!: bump @opentelemetry/sdk-trace-base to 2.x (drops vulnerable core <2.8.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@coralogix/opentelemetry",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coralogix/opentelemetry",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/sdk-trace-base": "^1.18.1",
+        "@opentelemetry/sdk-trace-base": "^2.8.0",
         "@opentelemetry/semantic-conventions": "^1.25.1"
       },
       "devDependencies": {
@@ -586,78 +586,58 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
-      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.18.1"
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
-      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
-      "engines": {
-        "node": ">=14"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.18.1.tgz",
-      "integrity": "sha512-JjbcQLYMttXcIabflLRuaw5oof5gToYV9fuXbcsoOeQ0BlbwUn6DAZi++PNsSz2jjPeASfDls10iaO/8BRIPRA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/semantic-conventions": "1.18.1"
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
-      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
-      "engines": {
-        "node": ">=14"
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.18.1.tgz",
-      "integrity": "sha512-tRHfDxN5dO+nop78EWJpzZwHsN1ewrZRVVwo03VJa3JQZxToRDH29/+MB24+yoa+IArerdr7INFJiX/iN4gjqg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/resources": "1.18.1",
-        "@opentelemetry/semantic-conventions": "1.18.1"
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
-      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
-      "engines": {
-        "node": ">=14"
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
-      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coralogix/opentelemetry",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coralogix/opentelemetry",
-      "version": "0.1.5",
+      "version": "0.2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/sdk-trace-base": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralogix/opentelemetry",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.7.0",
-    "@opentelemetry/sdk-trace-base": "^1.18.1",
+    "@opentelemetry/sdk-trace-base": "^2.8.0",
     "@opentelemetry/semantic-conventions": "^1.25.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralogix/opentelemetry",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/test/trace/samplers/coralogix-transaction-sampler.spec.ts
+++ b/test/trace/samplers/coralogix-transaction-sampler.spec.ts
@@ -5,19 +5,37 @@ import {Attributes, Context, createTraceState, Link, ROOT_CONTEXT, SpanKind, Tra
 import assert from "node:assert"
 import {
     BasicTracerProvider,
-    ReadableSpan,
+    InMemorySpanExporter,
     Sampler,
     SamplingDecision,
     SamplingResult,
+    SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
 import {CoralogixAttributes} from "../../../src/trace/common";
 import {isMatch} from 'lodash';
 
-// OTel 2.x no longer exports a concrete `Span` class to `instanceof` against, and the api `Span`
-// type does not expose `.attributes`. Recording spans returned by the SDK implement `ReadableSpan`,
-// so we read their recorded attributes through that type.
-const attributesOf = (span: opentelemetry.Span): ReadableSpan['attributes'] =>
-    (span as unknown as ReadableSpan).attributes;
+const NON_SAMPLED_ATTRIBUTE_NAME = 'non_sampled';
+
+// Builds a tracer whose spans are collected through the real SDK export pipeline. This lets the
+// tests assert on a span's recorded attributes via the public `ReadableSpan` contract
+// (`InMemorySpanExporter.getFinishedSpans()`) instead of reaching into the span implementation.
+function createTestTracer(sampler: Sampler = new CoralogixTransactionSampler()) {
+    const exporter = new InMemorySpanExporter();
+    const provider = new BasicTracerProvider({
+        sampler,
+        spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    return {tracer: provider.getTracer('default'), exporter};
+}
+
+// Resolves the exported span that corresponds to `span` and returns its recorded attributes.
+// Only sampled spans are exported, which is exactly the set of spans these tests inspect.
+function exportedAttributes(exporter: InMemorySpanExporter, span: opentelemetry.Span): Attributes {
+    const {spanId} = span.spanContext();
+    const finished = exporter.getFinishedSpans().find(s => s.spanContext().spanId === spanId);
+    assert.ok(finished, `expected span ${spanId} to have been exported`);
+    return finished.attributes;
+}
 
 export default describe('CoralogixTransactionSampler', () => {
     let context: Context = ROOT_CONTEXT;
@@ -90,10 +108,7 @@ export default describe('CoralogixTransactionSampler', () => {
 
     describe('transaction attribute', () => {
         it('propagate transaction through spans', () => {
-            const tracerProvider = new BasicTracerProvider({
-                sampler: new CoralogixTransactionSampler()
-            });
-            const tracer = tracerProvider.getTracer('default');
+            const {tracer, exporter} = createTestTracer();
 
             const span1 = tracer.startSpan('one', {}, context);
             context = opentelemetry.trace.setSpan(context, span1);
@@ -102,28 +117,20 @@ export default describe('CoralogixTransactionSampler', () => {
             const span3 = tracer.startSpan('three', {}, context);
             context = opentelemetry.trace.setSpan(context, span3);
 
-            if (span1.isRecording() && span2.isRecording() && span3.isRecording()) {
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
-                    'span1 must created a transaction attribute');
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
-                    'span2 must have transaction attribute from parent');
-                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
-                    'span3 must have transaction attribute from parent');
-            } else {
-                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
-                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
-                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
-            }
             span3.end();
             span2.end();
             span1.end();
+
+            assert.strictEqual(exportedAttributes(exporter, span1)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+                'span1 must create a transaction attribute');
+            assert.strictEqual(exportedAttributes(exporter, span2)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+                'span2 must have transaction attribute from parent');
+            assert.strictEqual(exportedAttributes(exporter, span3)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+                'span3 must have transaction attribute from parent');
         });
 
         it('propagate transaction attribute even if father is non recording', () => {
-            const tracerProvider = new BasicTracerProvider({
-                sampler: new CoralogixTransactionSampler(new TestAttributeSamplingSampler())
-            });
-            const tracer = tracerProvider.getTracer('default');
+            const {tracer, exporter} = createTestTracer(new CoralogixTransactionSampler(new TestAttributeSamplingSampler()));
 
             const span1 = tracer.startSpan('one', {attributes: {[NON_SAMPLED_ATTRIBUTE_NAME]: 'true'}}, context);
             context = opentelemetry.trace.setSpan(context, span1);
@@ -132,24 +139,18 @@ export default describe('CoralogixTransactionSampler', () => {
             const span3 = tracer.startSpan('three', {}, context);
             context = opentelemetry.trace.setSpan(context, span3);
 
-            if (!span1.isRecording() && !span2.isRecording() && span3.isRecording()) {
-                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
-                    'span3 must have transaction attribute from parent');
-            } else {
-                assert.ok(!span1.isRecording(), 'span1 must no be recording');
-                assert.ok(!span2.isRecording(), 'span2 must no be recording');
-                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
-            }
             span3.end();
             span2.end();
             span1.end();
+
+            assert.ok(!span1.isRecording(), 'span1 must not be recording');
+            assert.ok(!span2.isRecording(), 'span2 must not be recording');
+            assert.strictEqual(exportedAttributes(exporter, span3)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+                'span3 must have transaction attribute from parent');
         });
 
         it('create new transaction after remote span is initiated', () => {
-            const tracerProvider = new BasicTracerProvider({
-                sampler: new CoralogixTransactionSampler()
-            });
-            const tracer = tracerProvider.getTracer('default');
+            const {tracer, exporter} = createTestTracer();
 
             const span1 = tracer.startSpan('one', {}, context);
             context = opentelemetry.trace.setSpan(context, span1);
@@ -161,34 +162,25 @@ export default describe('CoralogixTransactionSampler', () => {
             const span4 = tracer.startSpan('four', {}, context);
             context = opentelemetry.trace.setSpan(context, span4);
 
-            if (span1.isRecording() && span2.isRecording() && span3.isRecording() && span4.isRecording()) {
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
-                    'span1 must created a transaction attribute');
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
-                    'span2 must have transaction attribute from parent');
-                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'three',
-                    'span3 must created a transaction attribute');
-                assert.strictEqual(attributesOf(span4)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'three',
-                    'span4 must have transaction attribute from parent');
-            } else {
-                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
-                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
-                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
-                assert.ok(span4.isRecording(), 'span4 must be instance of Span');
-            }
             span4.end();
             span3.end();
             span2.end();
             span1.end();
+
+            assert.strictEqual(exportedAttributes(exporter, span1)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+                'span1 must create a transaction attribute');
+            assert.strictEqual(exportedAttributes(exporter, span2)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+                'span2 must have transaction attribute from parent');
+            assert.strictEqual(exportedAttributes(exporter, span3)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'three',
+                'span3 must create a new transaction attribute after the remote span');
+            assert.strictEqual(exportedAttributes(exporter, span4)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'three',
+                'span4 must have transaction attribute from parent');
         });
     })
 
     describe('distributed transaction attribute', () => {
         it('propagate distributed transaction through spans', () => {
-            const tracerProvider = new BasicTracerProvider({
-                sampler: new CoralogixTransactionSampler()
-            });
-            const tracer = tracerProvider.getTracer('default');
+            const {tracer, exporter} = createTestTracer();
 
             const span1 = tracer.startSpan('one', {}, context);
             context = opentelemetry.trace.setSpan(context, span1);
@@ -197,28 +189,20 @@ export default describe('CoralogixTransactionSampler', () => {
             const span3 = tracer.startSpan('three', {}, context);
             context = opentelemetry.trace.setSpan(context, span3);
 
-            if (span1.isRecording() && span2.isRecording() && span3.isRecording()) {
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
-                    'span1 must created a distributed transaction attribute');
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
-                    'span2 must have distributed transaction attribute from parent');
-                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
-                    'span3 must have distributed transaction attribute from parent');
-            } else {
-                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
-                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
-                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
-            }
             span3.end();
             span2.end();
             span1.end();
+
+            assert.strictEqual(exportedAttributes(exporter, span1)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                'span1 must create a distributed transaction attribute');
+            assert.strictEqual(exportedAttributes(exporter, span2)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                'span2 must have distributed transaction attribute from parent');
+            assert.strictEqual(exportedAttributes(exporter, span3)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                'span3 must have distributed transaction attribute from parent');
         });
 
         it('propagate distributed transaction attribute even if father is non recording', () => {
-            const tracerProvider = new BasicTracerProvider({
-                sampler: new CoralogixTransactionSampler(new TestAttributeSamplingSampler())
-            });
-            const tracer = tracerProvider.getTracer('default');
+            const {tracer, exporter} = createTestTracer(new CoralogixTransactionSampler(new TestAttributeSamplingSampler()));
 
             const span1 = tracer.startSpan('one', {attributes: {[NON_SAMPLED_ATTRIBUTE_NAME]: 'true'}}, context);
             context = opentelemetry.trace.setSpan(context, span1);
@@ -227,25 +211,18 @@ export default describe('CoralogixTransactionSampler', () => {
             const span3 = tracer.startSpan('three', {}, context);
             context = opentelemetry.trace.setSpan(context, span3);
 
-            if (!span1.isRecording() && !span2.isRecording() && span3.isRecording()) {
-                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
-                    'span3 must have distributed transaction attribute from parent');
-            } else {
-                assert.ok(!span1.isRecording(), 'span1 must no be recording');
-                assert.ok(!span2.isRecording(), 'span2 must no be recording');
-                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
-            }
             span3.end();
             span2.end();
             span1.end();
 
+            assert.ok(!span1.isRecording(), 'span1 must not be recording');
+            assert.ok(!span2.isRecording(), 'span2 must not be recording');
+            assert.strictEqual(exportedAttributes(exporter, span3)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                'span3 must have distributed transaction attribute from parent');
         });
 
         it('propagate distributed transaction through remote spans', () => {
-            const tracerProvider = new BasicTracerProvider({
-                sampler: new CoralogixTransactionSampler()
-            });
-            const tracer = tracerProvider.getTracer('default');
+            const {tracer, exporter} = createTestTracer();
 
             const span1 = tracer.startSpan('one', {}, context);
             context = opentelemetry.trace.setSpan(context, span1);
@@ -257,34 +234,25 @@ export default describe('CoralogixTransactionSampler', () => {
             const span4 = tracer.startSpan('four', {}, context);
             context = opentelemetry.trace.setSpan(context, span4);
 
-            if (span1.isRecording() && span2.isRecording() && span3.isRecording() && span4.isRecording()) {
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
-                    'span1 must created a transaction attribute');
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
-                    'span2 must have distributed transaction attribute from parent');
-                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
-                    'span2 must have distributed transaction attribute from parent');
-                assert.strictEqual(attributesOf(span4)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
-                    'span4 must have distributed transaction attribute from parent');
-            } else {
-                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
-                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
-                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
-                assert.ok(span4.isRecording(), 'span4 must be instance of Span');
-            }
             span4.end();
             span3.end();
             span2.end();
             span1.end();
+
+            assert.strictEqual(exportedAttributes(exporter, span1)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                'span1 must create a distributed transaction attribute');
+            assert.strictEqual(exportedAttributes(exporter, span2)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                'span2 must have distributed transaction attribute from parent');
+            assert.strictEqual(exportedAttributes(exporter, span3)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                'span3 must keep the distributed transaction attribute across the remote span');
+            assert.strictEqual(exportedAttributes(exporter, span4)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                'span4 must have distributed transaction attribute from parent');
         });
     })
 
     describe('transaction root attribute', () => {
         it('add transaction root attribute to creator of transaction', () => {
-            const tracerProvider = new BasicTracerProvider({
-                sampler: new CoralogixTransactionSampler()
-            });
-            const tracer = tracerProvider.getTracer('default');
+            const {tracer, exporter} = createTestTracer();
 
             const span1 = tracer.startSpan('one', {}, context);
             context = opentelemetry.trace.setSpan(context, span1);
@@ -293,28 +261,20 @@ export default describe('CoralogixTransactionSampler', () => {
             const span3 = tracer.startSpan('three', {}, context);
             context = opentelemetry.trace.setSpan(context, span3);
 
-            if (span1.isRecording() && span2.isRecording() && span3.isRecording()) {
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_ROOT], true,
-                    'span1 must have transaction root');
-                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in attributesOf(span2)),
-                    'span2 must not have transaction root');
-                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in attributesOf(span3)),
-                    'span3 must not have transaction root');
-            } else {
-                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
-                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
-                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
-            }
             span3.end();
             span2.end();
             span1.end();
+
+            assert.strictEqual(exportedAttributes(exporter, span1)[CoralogixAttributes.TRANSACTION_ROOT], true,
+                'span1 must have transaction root');
+            assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in exportedAttributes(exporter, span2)),
+                'span2 must not have transaction root');
+            assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in exportedAttributes(exporter, span3)),
+                'span3 must not have transaction root');
         });
 
         it('add transaction root attribute span after remote', () => {
-            const tracerProvider = new BasicTracerProvider({
-                sampler: new CoralogixTransactionSampler()
-            });
-            const tracer = tracerProvider.getTracer('default');
+            const {tracer, exporter} = createTestTracer();
 
             const span1 = tracer.startSpan('one', {}, context);
             context = opentelemetry.trace.setSpan(context, span1);
@@ -326,53 +286,38 @@ export default describe('CoralogixTransactionSampler', () => {
             const span4 = tracer.startSpan('four', {}, context);
             context = opentelemetry.trace.setSpan(context, span4);
 
-            if (span1.isRecording() && span2.isRecording() && span3.isRecording() && span4.isRecording()) {
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_ROOT], true,
-                    'span1 must have transaction root');
-                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in attributesOf(span2)),
-                    'span2 must not have transaction root');
-                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.TRANSACTION_ROOT], true,
-                    'span3 must have transaction root');
-                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in attributesOf(span4)),
-                    'span4 must not have transaction root');
-            } else {
-                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
-                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
-                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
-                assert.ok(span4.isRecording(), 'span4 must be instance of Span');
-            }
             span4.end();
             span3.end();
             span2.end();
             span1.end();
+
+            assert.strictEqual(exportedAttributes(exporter, span1)[CoralogixAttributes.TRANSACTION_ROOT], true,
+                'span1 must have transaction root');
+            assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in exportedAttributes(exporter, span2)),
+                'span2 must not have transaction root');
+            assert.strictEqual(exportedAttributes(exporter, span3)[CoralogixAttributes.TRANSACTION_ROOT], true,
+                'span3 must have transaction root');
+            assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in exportedAttributes(exporter, span4)),
+                'span4 must not have transaction root');
         });
 
         it('span with same name as transaction span should not be root transaction', () => {
-            const tracerProvider = new BasicTracerProvider({
-                sampler: new CoralogixTransactionSampler()
-            });
-            const tracer = tracerProvider.getTracer('default');
+            const {tracer, exporter} = createTestTracer();
 
             const span1 = tracer.startSpan('one', {}, context);
             context = opentelemetry.trace.setSpan(context, span1);
             const span2 = tracer.startSpan('one', {}, context);
             context = opentelemetry.trace.setSpan(context, span2);
 
-            if (span1.isRecording() && span2.isRecording()) {
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_ROOT], true,
-                    'span1 must have transaction root');
-                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in attributesOf(span2)),
-                    'span1 must not have transaction root');
-            } else {
-                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
-                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
-            }
             span2.end();
             span1.end();
+
+            assert.strictEqual(exportedAttributes(exporter, span1)[CoralogixAttributes.TRANSACTION_ROOT], true,
+                'span1 must have transaction root');
+            assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in exportedAttributes(exporter, span2)),
+                'span2 must not have transaction root');
         });
     })
-
-    const NON_SAMPLED_ATTRIBUTE_NAME = 'non_sampled';
 
     class TestAttributeSamplingSampler implements Sampler {
 

--- a/test/trace/samplers/coralogix-transaction-sampler.spec.ts
+++ b/test/trace/samplers/coralogix-transaction-sampler.spec.ts
@@ -5,13 +5,19 @@ import {Attributes, Context, createTraceState, Link, ROOT_CONTEXT, SpanKind, Tra
 import assert from "node:assert"
 import {
     BasicTracerProvider,
+    ReadableSpan,
     Sampler,
     SamplingDecision,
     SamplingResult,
-    Span,
 } from "@opentelemetry/sdk-trace-base";
 import {CoralogixAttributes} from "../../../src/trace/common";
 import {isMatch} from 'lodash';
+
+// OTel 2.x no longer exports a concrete `Span` class to `instanceof` against, and the api `Span`
+// type does not expose `.attributes`. Recording spans returned by the SDK implement `ReadableSpan`,
+// so we read their recorded attributes through that type.
+const attributesOf = (span: opentelemetry.Span): ReadableSpan['attributes'] =>
+    (span as unknown as ReadableSpan).attributes;
 
 export default describe('CoralogixTransactionSampler', () => {
     let context: Context = ROOT_CONTEXT;
@@ -96,17 +102,17 @@ export default describe('CoralogixTransactionSampler', () => {
             const span3 = tracer.startSpan('three', {}, context);
             context = opentelemetry.trace.setSpan(context, span3);
 
-            if (span1 instanceof Span && span2 instanceof Span && span3 instanceof Span) {
-                assert.strictEqual(span1.attributes[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+            if (span1.isRecording() && span2.isRecording() && span3.isRecording()) {
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
                     'span1 must created a transaction attribute');
-                assert.strictEqual(span1.attributes[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
                     'span2 must have transaction attribute from parent');
-                assert.strictEqual(span3.attributes[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
                     'span3 must have transaction attribute from parent');
             } else {
-                assert.ok(span1 instanceof Span, 'span1 must be instance of Span');
-                assert.ok(span2 instanceof Span, 'span2 must be instance of Span');
-                assert.ok(span3 instanceof Span, 'span3 must be instance of Span');
+                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
+                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
+                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
             }
             span3.end();
             span2.end();
@@ -126,13 +132,13 @@ export default describe('CoralogixTransactionSampler', () => {
             const span3 = tracer.startSpan('three', {}, context);
             context = opentelemetry.trace.setSpan(context, span3);
 
-            if (!span1.isRecording() && !span2.isRecording() && span3 instanceof Span) {
-                assert.strictEqual(span3.attributes[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+            if (!span1.isRecording() && !span2.isRecording() && span3.isRecording()) {
+                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
                     'span3 must have transaction attribute from parent');
             } else {
                 assert.ok(!span1.isRecording(), 'span1 must no be recording');
                 assert.ok(!span2.isRecording(), 'span2 must no be recording');
-                assert.ok(span3 instanceof Span, 'span3 must be instance of Span');
+                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
             }
             span3.end();
             span2.end();
@@ -155,20 +161,20 @@ export default describe('CoralogixTransactionSampler', () => {
             const span4 = tracer.startSpan('four', {}, context);
             context = opentelemetry.trace.setSpan(context, span4);
 
-            if (span1 instanceof Span && span2 instanceof Span && span3 instanceof Span && span4 instanceof Span) {
-                assert.strictEqual(span1.attributes[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+            if (span1.isRecording() && span2.isRecording() && span3.isRecording() && span4.isRecording()) {
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
                     'span1 must created a transaction attribute');
-                assert.strictEqual(span1.attributes[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
                     'span2 must have transaction attribute from parent');
-                assert.strictEqual(span3.attributes[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'three',
+                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'three',
                     'span3 must created a transaction attribute');
-                assert.strictEqual(span4.attributes[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'three',
+                assert.strictEqual(attributesOf(span4)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'three',
                     'span4 must have transaction attribute from parent');
             } else {
-                assert.ok(span1 instanceof Span, 'span1 must be instance of Span');
-                assert.ok(span2 instanceof Span, 'span2 must be instance of Span');
-                assert.ok(span3 instanceof Span, 'span3 must be instance of Span');
-                assert.ok(span4 instanceof Span, 'span4 must be instance of Span');
+                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
+                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
+                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
+                assert.ok(span4.isRecording(), 'span4 must be instance of Span');
             }
             span4.end();
             span3.end();
@@ -191,17 +197,17 @@ export default describe('CoralogixTransactionSampler', () => {
             const span3 = tracer.startSpan('three', {}, context);
             context = opentelemetry.trace.setSpan(context, span3);
 
-            if (span1 instanceof Span && span2 instanceof Span && span3 instanceof Span) {
-                assert.strictEqual(span1.attributes[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+            if (span1.isRecording() && span2.isRecording() && span3.isRecording()) {
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
                     'span1 must created a distributed transaction attribute');
-                assert.strictEqual(span1.attributes[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
                     'span2 must have distributed transaction attribute from parent');
-                assert.strictEqual(span3.attributes[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
                     'span3 must have distributed transaction attribute from parent');
             } else {
-                assert.ok(span1 instanceof Span, 'span1 must be instance of Span');
-                assert.ok(span2 instanceof Span, 'span2 must be instance of Span');
-                assert.ok(span3 instanceof Span, 'span3 must be instance of Span');
+                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
+                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
+                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
             }
             span3.end();
             span2.end();
@@ -221,13 +227,13 @@ export default describe('CoralogixTransactionSampler', () => {
             const span3 = tracer.startSpan('three', {}, context);
             context = opentelemetry.trace.setSpan(context, span3);
 
-            if (!span1.isRecording() && !span2.isRecording() && span3 instanceof Span) {
-                assert.strictEqual(span3.attributes[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+            if (!span1.isRecording() && !span2.isRecording() && span3.isRecording()) {
+                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
                     'span3 must have distributed transaction attribute from parent');
             } else {
                 assert.ok(!span1.isRecording(), 'span1 must no be recording');
                 assert.ok(!span2.isRecording(), 'span2 must no be recording');
-                assert.ok(span3 instanceof Span, 'span3 must be instance of Span');
+                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
             }
             span3.end();
             span2.end();
@@ -251,20 +257,20 @@ export default describe('CoralogixTransactionSampler', () => {
             const span4 = tracer.startSpan('four', {}, context);
             context = opentelemetry.trace.setSpan(context, span4);
 
-            if (span1 instanceof Span && span2 instanceof Span && span3 instanceof Span && span4 instanceof Span) {
-                assert.strictEqual(span1.attributes[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+            if (span1.isRecording() && span2.isRecording() && span3.isRecording() && span4.isRecording()) {
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
                     'span1 must created a transaction attribute');
-                assert.strictEqual(span1.attributes[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
                     'span2 must have distributed transaction attribute from parent');
-                assert.strictEqual(span3.attributes[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
                     'span2 must have distributed transaction attribute from parent');
-                assert.strictEqual(span4.attributes[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                assert.strictEqual(attributesOf(span4)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
                     'span4 must have distributed transaction attribute from parent');
             } else {
-                assert.ok(span1 instanceof Span, 'span1 must be instance of Span');
-                assert.ok(span2 instanceof Span, 'span2 must be instance of Span');
-                assert.ok(span3 instanceof Span, 'span3 must be instance of Span');
-                assert.ok(span4 instanceof Span, 'span4 must be instance of Span');
+                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
+                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
+                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
+                assert.ok(span4.isRecording(), 'span4 must be instance of Span');
             }
             span4.end();
             span3.end();
@@ -287,17 +293,17 @@ export default describe('CoralogixTransactionSampler', () => {
             const span3 = tracer.startSpan('three', {}, context);
             context = opentelemetry.trace.setSpan(context, span3);
 
-            if (span1 instanceof Span && span2 instanceof Span && span3 instanceof Span) {
-                assert.strictEqual(span1.attributes[CoralogixAttributes.TRANSACTION_ROOT], true,
+            if (span1.isRecording() && span2.isRecording() && span3.isRecording()) {
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_ROOT], true,
                     'span1 must have transaction root');
-                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in span2.attributes),
+                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in attributesOf(span2)),
                     'span2 must not have transaction root');
-                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in span3.attributes),
+                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in attributesOf(span3)),
                     'span3 must not have transaction root');
             } else {
-                assert.ok(span1 instanceof Span, 'span1 must be instance of Span');
-                assert.ok(span2 instanceof Span, 'span2 must be instance of Span');
-                assert.ok(span3 instanceof Span, 'span3 must be instance of Span');
+                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
+                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
+                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
             }
             span3.end();
             span2.end();
@@ -320,20 +326,20 @@ export default describe('CoralogixTransactionSampler', () => {
             const span4 = tracer.startSpan('four', {}, context);
             context = opentelemetry.trace.setSpan(context, span4);
 
-            if (span1 instanceof Span && span2 instanceof Span && span3 instanceof Span && span4 instanceof Span) {
-                assert.strictEqual(span1.attributes[CoralogixAttributes.TRANSACTION_ROOT], true,
+            if (span1.isRecording() && span2.isRecording() && span3.isRecording() && span4.isRecording()) {
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_ROOT], true,
                     'span1 must have transaction root');
-                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in span2.attributes),
+                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in attributesOf(span2)),
                     'span2 must not have transaction root');
-                assert.strictEqual(span3.attributes[CoralogixAttributes.TRANSACTION_ROOT], true,
+                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.TRANSACTION_ROOT], true,
                     'span3 must have transaction root');
-                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in span4.attributes),
+                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in attributesOf(span4)),
                     'span4 must not have transaction root');
             } else {
-                assert.ok(span1 instanceof Span, 'span1 must be instance of Span');
-                assert.ok(span2 instanceof Span, 'span2 must be instance of Span');
-                assert.ok(span3 instanceof Span, 'span3 must be instance of Span');
-                assert.ok(span4 instanceof Span, 'span4 must be instance of Span');
+                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
+                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
+                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
+                assert.ok(span4.isRecording(), 'span4 must be instance of Span');
             }
             span4.end();
             span3.end();
@@ -352,14 +358,14 @@ export default describe('CoralogixTransactionSampler', () => {
             const span2 = tracer.startSpan('one', {}, context);
             context = opentelemetry.trace.setSpan(context, span2);
 
-            if (span1 instanceof Span && span2 instanceof Span) {
-                assert.strictEqual(span1.attributes[CoralogixAttributes.TRANSACTION_ROOT], true,
+            if (span1.isRecording() && span2.isRecording()) {
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_ROOT], true,
                     'span1 must have transaction root');
-                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in span2.attributes),
+                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in attributesOf(span2)),
                     'span1 must not have transaction root');
             } else {
-                assert.ok(span1 instanceof Span, 'span1 must be instance of Span');
-                assert.ok(span2 instanceof Span, 'span2 must be instance of Span');
+                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
+                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
             }
             span2.end();
             span1.end();


### PR DESCRIPTION
## Summary

Bumps `@opentelemetry/sdk-trace-base` `^1.18.1` → `^2.8.0` so the transitive `@opentelemetry/core` resolves to **2.8.0** and is no longer affected by **CVE-2026-54285 / GHSA-8988-4f7v-96qf** (unbounded memory allocation in W3C Baggage propagation — the entire `<2.8.0` range is vulnerable).

This package's published dependency on the 1.x SDK is the last source of a vulnerable `@opentelemetry/core` copy in downstream consumers (e.g. `@cx/tracer@2.0.0`, which already runs on the OTel 2.x stack but pulls this package in transitively).

## Changes

- `dependencies`: `@opentelemetry/sdk-trace-base` `^1.18.1` → `^2.8.0`. `@opentelemetry/api` (`^1.7.0`) and `@opentelemetry/semantic-conventions` (`^1.25.1`) are unchanged — both remain 1.x in the OTel 2.x ecosystem.
- `version`: `0.1.4` → **`0.2.0`** (minor). Moving the peer OTel SDK across a major (1.x → 2.x) is a behavioral change for consumers; under 0.x semver that is a minor, not a patch.
- **No source/public-API changes.** All imported symbols (`AlwaysOnSampler`, `ParentBasedSampler`, `Sampler`, `SamplingResult`) still exist in `sdk-trace-base@2.x`.
- **Test update for OTel 2.x:** `sdk-trace-base` no longer exports a concrete `Span` class to `instanceof` against, and the api `Span` type no longer exposes `.attributes`. The sampler spec now collects spans through a real `SimpleSpanProcessor` + `InMemorySpanExporter` and asserts on the exported `ReadableSpan` attributes via the public API (no casts). This also fixes a latent bug where several `span2`/`span3` assertions actually re-read `span1`.

## Validation

- `npm run build` — passes (CJS + ESM + DTS).
- `npm test` (`tsc && eslint && node --test`) — passes; **19/19** unit tests green.
- `npm ci` — lockfile in sync; `@opentelemetry/core` resolves to `2.8.0` only.

## Downstream impact

Because this is `0.2.0`, consumers pinned to `^0.1.x` will **not** auto-upgrade. To propagate the fix:
- `@cx/tracer` should widen its `@coralogix/opentelemetry` range to `^0.2.0`.
- Then `eng-svc-dashboards-reporter` (INFOSEC-8085) can drop its temporary `@opentelemetry/core`/`resources`/`sdk-trace-base` `overrides`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)