### PR TITLE
fix(sampler): migrate http.target → stable url.path (with legacy fallback)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@coralogix/opentelemetry",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coralogix/opentelemetry",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/sdk-trace-base": "^1.18.1",
+        "@opentelemetry/sdk-trace-base": "^2.8.0",
         "@opentelemetry/semantic-conventions": "^1.25.1"
       },
       "devDependencies": {
@@ -586,78 +586,58 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
-      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.18.1"
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
-      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
-      "engines": {
-        "node": ">=14"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.18.1.tgz",
-      "integrity": "sha512-JjbcQLYMttXcIabflLRuaw5oof5gToYV9fuXbcsoOeQ0BlbwUn6DAZi++PNsSz2jjPeASfDls10iaO/8BRIPRA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/semantic-conventions": "1.18.1"
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
-      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
-      "engines": {
-        "node": ">=14"
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.18.1.tgz",
-      "integrity": "sha512-tRHfDxN5dO+nop78EWJpzZwHsN1ewrZRVVwo03VJa3JQZxToRDH29/+MB24+yoa+IArerdr7INFJiX/iN4gjqg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/resources": "1.18.1",
-        "@opentelemetry/semantic-conventions": "1.18.1"
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
-      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
-      "engines": {
-        "node": ">=14"
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
-      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coralogix/opentelemetry",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coralogix/opentelemetry",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/sdk-trace-base": "^2.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coralogix/opentelemetry",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coralogix/opentelemetry",
-      "version": "0.1.5",
+      "version": "0.2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/sdk-trace-base": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralogix/opentelemetry",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.7.0",
-    "@opentelemetry/sdk-trace-base": "^1.18.1",
+    "@opentelemetry/sdk-trace-base": "^2.8.0",
     "@opentelemetry/semantic-conventions": "^1.25.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralogix/opentelemetry",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralogix/opentelemetry",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/src/trace/samplers/coralogix-transaction-sampler.ts
+++ b/src/trace/samplers/coralogix-transaction-sampler.ts
@@ -4,7 +4,13 @@ import * as opentelemetry from "@opentelemetry/api";
 import {CoralogixAttributes, CoralogixTraceState} from "../common";
 import type express from 'express';
 import {ILayer} from "express-serve-static-core";
-import {SEMATTRS_HTTP_TARGET} from "@opentelemetry/semantic-conventions";
+import {ATTR_URL_PATH} from "@opentelemetry/semantic-conventions";
+
+// `http.target` is the legacy (pre-stability) HTTP attribute. It was removed from the stable
+// semantic-conventions entry point in favour of `url.path`, but instrumentations that have not
+// opted into stable HTTP semconv (OTEL_SEMCONV_STABILITY_OPT_IN) still emit it. Read the stable
+// `url.path` first and fall back to the legacy attribute so route resolution works in every mode.
+const ATTR_HTTP_TARGET_LEGACY = "http.target";
 
 export interface RouteMapping {
     matches: (path: string) => boolean,
@@ -114,7 +120,7 @@ export class CoralogixTransactionSampler implements Sampler {
         try {
             const spanContext = opentelemetry.trace.getSpanContext(context);
 
-            const httpTarget = attributes?.[SEMATTRS_HTTP_TARGET]?.toString();
+            const httpTarget = (attributes?.[ATTR_URL_PATH] ?? attributes?.[ATTR_HTTP_TARGET_LEGACY])?.toString();
             const path = this._getPathFromRoutes(httpTarget ?? '');
 
             const transactionName = path ? this._buildTransactionNameFromExpressPath(path, spanName) : spanName;

--- a/test/trace/samplers/coralogix-transaction-sampler.spec.ts
+++ b/test/trace/samplers/coralogix-transaction-sampler.spec.ts
@@ -5,19 +5,37 @@ import {Attributes, Context, createTraceState, Link, ROOT_CONTEXT, SpanKind, Tra
 import assert from "node:assert"
 import {
     BasicTracerProvider,
-    ReadableSpan,
+    InMemorySpanExporter,
     Sampler,
     SamplingDecision,
     SamplingResult,
+    SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
 import {CoralogixAttributes} from "../../../src/trace/common";
 import {isMatch} from 'lodash';
 
-// OTel 2.x no longer exports a concrete `Span` class to `instanceof` against, and the api `Span`
-// type does not expose `.attributes`. Recording spans returned by the SDK implement `ReadableSpan`,
-// so we read their recorded attributes through that type.
-const attributesOf = (span: opentelemetry.Span): ReadableSpan['attributes'] =>
-    (span as unknown as ReadableSpan).attributes;
+const NON_SAMPLED_ATTRIBUTE_NAME = 'non_sampled';
+
+// Builds a tracer whose spans are collected through the real SDK export pipeline. This lets the
+// tests assert on a span's recorded attributes via the public `ReadableSpan` contract
+// (`InMemorySpanExporter.getFinishedSpans()`) instead of reaching into the span implementation.
+function createTestTracer(sampler: Sampler = new CoralogixTransactionSampler()) {
+    const exporter = new InMemorySpanExporter();
+    const provider = new BasicTracerProvider({
+        sampler,
+        spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    return {tracer: provider.getTracer('default'), exporter};
+}
+
+// Resolves the exported span that corresponds to `span` and returns its recorded attributes.
+// Only sampled spans are exported, which is exactly the set of spans these tests inspect.
+function exportedAttributes(exporter: InMemorySpanExporter, span: opentelemetry.Span): Attributes {
+    const {spanId} = span.spanContext();
+    const finished = exporter.getFinishedSpans().find(s => s.spanContext().spanId === spanId);
+    assert.ok(finished, `expected span ${spanId} to have been exported`);
+    return finished.attributes;
+}
 
 export default describe('CoralogixTransactionSampler', () => {
     let context: Context = ROOT_CONTEXT;
@@ -90,10 +108,7 @@ export default describe('CoralogixTransactionSampler', () => {
 
     describe('transaction attribute', () => {
         it('propagate transaction through spans', () => {
-            const tracerProvider = new BasicTracerProvider({
-                sampler: new CoralogixTransactionSampler()
-            });
-            const tracer = tracerProvider.getTracer('default');
+            const {tracer, exporter} = createTestTracer();
 
             const span1 = tracer.startSpan('one', {}, context);
             context = opentelemetry.trace.setSpan(context, span1);
@@ -102,28 +117,20 @@ export default describe('CoralogixTransactionSampler', () => {
             const span3 = tracer.startSpan('three', {}, context);
             context = opentelemetry.trace.setSpan(context, span3);
 
-            if (span1.isRecording() && span2.isRecording() && span3.isRecording()) {
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
-                    'span1 must created a transaction attribute');
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
-                    'span2 must have transaction attribute from parent');
-                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
-                    'span3 must have transaction attribute from parent');
-            } else {
-                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
-                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
-                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
-            }
             span3.end();
             span2.end();
             span1.end();
+
+            assert.strictEqual(exportedAttributes(exporter, span1)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+                'span1 must create a transaction attribute');
+            assert.strictEqual(exportedAttributes(exporter, span2)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+                'span2 must have transaction attribute from parent');
+            assert.strictEqual(exportedAttributes(exporter, span3)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+                'span3 must have transaction attribute from parent');
         });
 
         it('propagate transaction attribute even if father is non recording', () => {
-            const tracerProvider = new BasicTracerProvider({
-                sampler: new CoralogixTransactionSampler(new TestAttributeSamplingSampler())
-            });
-            const tracer = tracerProvider.getTracer('default');
+            const {tracer, exporter} = createTestTracer(new CoralogixTransactionSampler(new TestAttributeSamplingSampler()));
 
             const span1 = tracer.startSpan('one', {attributes: {[NON_SAMPLED_ATTRIBUTE_NAME]: 'true'}}, context);
             context = opentelemetry.trace.setSpan(context, span1);
@@ -132,24 +139,18 @@ export default describe('CoralogixTransactionSampler', () => {
             const span3 = tracer.startSpan('three', {}, context);
             context = opentelemetry.trace.setSpan(context, span3);
 
-            if (!span1.isRecording() && !span2.isRecording() && span3.isRecording()) {
-                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
-                    'span3 must have transaction attribute from parent');
-            } else {
-                assert.ok(!span1.isRecording(), 'span1 must no be recording');
-                assert.ok(!span2.isRecording(), 'span2 must no be recording');
-                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
-            }
             span3.end();
             span2.end();
             span1.end();
+
+            assert.ok(!span1.isRecording(), 'span1 must not be recording');
+            assert.ok(!span2.isRecording(), 'span2 must not be recording');
+            assert.strictEqual(exportedAttributes(exporter, span3)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+                'span3 must have transaction attribute from parent');
         });
 
         it('create new transaction after remote span is initiated', () => {
-            const tracerProvider = new BasicTracerProvider({
-                sampler: new CoralogixTransactionSampler()
-            });
-            const tracer = tracerProvider.getTracer('default');
+            const {tracer, exporter} = createTestTracer();
 
             const span1 = tracer.startSpan('one', {}, context);
             context = opentelemetry.trace.setSpan(context, span1);
@@ -161,34 +162,25 @@ export default describe('CoralogixTransactionSampler', () => {
             const span4 = tracer.startSpan('four', {}, context);
             context = opentelemetry.trace.setSpan(context, span4);
 
-            if (span1.isRecording() && span2.isRecording() && span3.isRecording() && span4.isRecording()) {
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
-                    'span1 must created a transaction attribute');
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
-                    'span2 must have transaction attribute from parent');
-                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'three',
-                    'span3 must created a transaction attribute');
-                assert.strictEqual(attributesOf(span4)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'three',
-                    'span4 must have transaction attribute from parent');
-            } else {
-                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
-                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
-                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
-                assert.ok(span4.isRecording(), 'span4 must be instance of Span');
-            }
             span4.end();
             span3.end();
             span2.end();
             span1.end();
+
+            assert.strictEqual(exportedAttributes(exporter, span1)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+                'span1 must create a transaction attribute');
+            assert.strictEqual(exportedAttributes(exporter, span2)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+                'span2 must have transaction attribute from parent');
+            assert.strictEqual(exportedAttributes(exporter, span3)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'three',
+                'span3 must create a new transaction attribute after the remote span');
+            assert.strictEqual(exportedAttributes(exporter, span4)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'three',
+                'span4 must have transaction attribute from parent');
         });
     })
 
     describe('distributed transaction attribute', () => {
         it('propagate distributed transaction through spans', () => {
-            const tracerProvider = new BasicTracerProvider({
-                sampler: new CoralogixTransactionSampler()
-            });
-            const tracer = tracerProvider.getTracer('default');
+            const {tracer, exporter} = createTestTracer();
 
             const span1 = tracer.startSpan('one', {}, context);
             context = opentelemetry.trace.setSpan(context, span1);
@@ -197,28 +189,20 @@ export default describe('CoralogixTransactionSampler', () => {
             const span3 = tracer.startSpan('three', {}, context);
             context = opentelemetry.trace.setSpan(context, span3);
 
-            if (span1.isRecording() && span2.isRecording() && span3.isRecording()) {
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
-                    'span1 must created a distributed transaction attribute');
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
-                    'span2 must have distributed transaction attribute from parent');
-                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
-                    'span3 must have distributed transaction attribute from parent');
-            } else {
-                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
-                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
-                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
-            }
             span3.end();
             span2.end();
             span1.end();
+
+            assert.strictEqual(exportedAttributes(exporter, span1)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                'span1 must create a distributed transaction attribute');
+            assert.strictEqual(exportedAttributes(exporter, span2)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                'span2 must have distributed transaction attribute from parent');
+            assert.strictEqual(exportedAttributes(exporter, span3)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                'span3 must have distributed transaction attribute from parent');
         });
 
         it('propagate distributed transaction attribute even if father is non recording', () => {
-            const tracerProvider = new BasicTracerProvider({
-                sampler: new CoralogixTransactionSampler(new TestAttributeSamplingSampler())
-            });
-            const tracer = tracerProvider.getTracer('default');
+            const {tracer, exporter} = createTestTracer(new CoralogixTransactionSampler(new TestAttributeSamplingSampler()));
 
             const span1 = tracer.startSpan('one', {attributes: {[NON_SAMPLED_ATTRIBUTE_NAME]: 'true'}}, context);
             context = opentelemetry.trace.setSpan(context, span1);
@@ -227,25 +211,18 @@ export default describe('CoralogixTransactionSampler', () => {
             const span3 = tracer.startSpan('three', {}, context);
             context = opentelemetry.trace.setSpan(context, span3);
 
-            if (!span1.isRecording() && !span2.isRecording() && span3.isRecording()) {
-                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
-                    'span3 must have distributed transaction attribute from parent');
-            } else {
-                assert.ok(!span1.isRecording(), 'span1 must no be recording');
-                assert.ok(!span2.isRecording(), 'span2 must no be recording');
-                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
-            }
             span3.end();
             span2.end();
             span1.end();
 
+            assert.ok(!span1.isRecording(), 'span1 must not be recording');
+            assert.ok(!span2.isRecording(), 'span2 must not be recording');
+            assert.strictEqual(exportedAttributes(exporter, span3)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                'span3 must have distributed transaction attribute from parent');
         });
 
         it('propagate distributed transaction through remote spans', () => {
-            const tracerProvider = new BasicTracerProvider({
-                sampler: new CoralogixTransactionSampler()
-            });
-            const tracer = tracerProvider.getTracer('default');
+            const {tracer, exporter} = createTestTracer();
 
             const span1 = tracer.startSpan('one', {}, context);
             context = opentelemetry.trace.setSpan(context, span1);
@@ -257,34 +234,25 @@ export default describe('CoralogixTransactionSampler', () => {
             const span4 = tracer.startSpan('four', {}, context);
             context = opentelemetry.trace.setSpan(context, span4);
 
-            if (span1.isRecording() && span2.isRecording() && span3.isRecording() && span4.isRecording()) {
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
-                    'span1 must created a transaction attribute');
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
-                    'span2 must have distributed transaction attribute from parent');
-                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
-                    'span2 must have distributed transaction attribute from parent');
-                assert.strictEqual(attributesOf(span4)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
-                    'span4 must have distributed transaction attribute from parent');
-            } else {
-                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
-                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
-                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
-                assert.ok(span4.isRecording(), 'span4 must be instance of Span');
-            }
             span4.end();
             span3.end();
             span2.end();
             span1.end();
+
+            assert.strictEqual(exportedAttributes(exporter, span1)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                'span1 must create a distributed transaction attribute');
+            assert.strictEqual(exportedAttributes(exporter, span2)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                'span2 must have distributed transaction attribute from parent');
+            assert.strictEqual(exportedAttributes(exporter, span3)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                'span3 must keep the distributed transaction attribute across the remote span');
+            assert.strictEqual(exportedAttributes(exporter, span4)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                'span4 must have distributed transaction attribute from parent');
         });
     })
 
     describe('transaction root attribute', () => {
         it('add transaction root attribute to creator of transaction', () => {
-            const tracerProvider = new BasicTracerProvider({
-                sampler: new CoralogixTransactionSampler()
-            });
-            const tracer = tracerProvider.getTracer('default');
+            const {tracer, exporter} = createTestTracer();
 
             const span1 = tracer.startSpan('one', {}, context);
             context = opentelemetry.trace.setSpan(context, span1);
@@ -293,28 +261,20 @@ export default describe('CoralogixTransactionSampler', () => {
             const span3 = tracer.startSpan('three', {}, context);
             context = opentelemetry.trace.setSpan(context, span3);
 
-            if (span1.isRecording() && span2.isRecording() && span3.isRecording()) {
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_ROOT], true,
-                    'span1 must have transaction root');
-                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in attributesOf(span2)),
-                    'span2 must not have transaction root');
-                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in attributesOf(span3)),
-                    'span3 must not have transaction root');
-            } else {
-                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
-                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
-                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
-            }
             span3.end();
             span2.end();
             span1.end();
+
+            assert.strictEqual(exportedAttributes(exporter, span1)[CoralogixAttributes.TRANSACTION_ROOT], true,
+                'span1 must have transaction root');
+            assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in exportedAttributes(exporter, span2)),
+                'span2 must not have transaction root');
+            assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in exportedAttributes(exporter, span3)),
+                'span3 must not have transaction root');
         });
 
         it('add transaction root attribute span after remote', () => {
-            const tracerProvider = new BasicTracerProvider({
-                sampler: new CoralogixTransactionSampler()
-            });
-            const tracer = tracerProvider.getTracer('default');
+            const {tracer, exporter} = createTestTracer();
 
             const span1 = tracer.startSpan('one', {}, context);
             context = opentelemetry.trace.setSpan(context, span1);
@@ -326,53 +286,38 @@ export default describe('CoralogixTransactionSampler', () => {
             const span4 = tracer.startSpan('four', {}, context);
             context = opentelemetry.trace.setSpan(context, span4);
 
-            if (span1.isRecording() && span2.isRecording() && span3.isRecording() && span4.isRecording()) {
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_ROOT], true,
-                    'span1 must have transaction root');
-                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in attributesOf(span2)),
-                    'span2 must not have transaction root');
-                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.TRANSACTION_ROOT], true,
-                    'span3 must have transaction root');
-                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in attributesOf(span4)),
-                    'span4 must not have transaction root');
-            } else {
-                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
-                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
-                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
-                assert.ok(span4.isRecording(), 'span4 must be instance of Span');
-            }
             span4.end();
             span3.end();
             span2.end();
             span1.end();
+
+            assert.strictEqual(exportedAttributes(exporter, span1)[CoralogixAttributes.TRANSACTION_ROOT], true,
+                'span1 must have transaction root');
+            assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in exportedAttributes(exporter, span2)),
+                'span2 must not have transaction root');
+            assert.strictEqual(exportedAttributes(exporter, span3)[CoralogixAttributes.TRANSACTION_ROOT], true,
+                'span3 must have transaction root');
+            assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in exportedAttributes(exporter, span4)),
+                'span4 must not have transaction root');
         });
 
         it('span with same name as transaction span should not be root transaction', () => {
-            const tracerProvider = new BasicTracerProvider({
-                sampler: new CoralogixTransactionSampler()
-            });
-            const tracer = tracerProvider.getTracer('default');
+            const {tracer, exporter} = createTestTracer();
 
             const span1 = tracer.startSpan('one', {}, context);
             context = opentelemetry.trace.setSpan(context, span1);
             const span2 = tracer.startSpan('one', {}, context);
             context = opentelemetry.trace.setSpan(context, span2);
 
-            if (span1.isRecording() && span2.isRecording()) {
-                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_ROOT], true,
-                    'span1 must have transaction root');
-                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in attributesOf(span2)),
-                    'span1 must not have transaction root');
-            } else {
-                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
-                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
-            }
             span2.end();
             span1.end();
+
+            assert.strictEqual(exportedAttributes(exporter, span1)[CoralogixAttributes.TRANSACTION_ROOT], true,
+                'span1 must have transaction root');
+            assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in exportedAttributes(exporter, span2)),
+                'span2 must not have transaction root');
         });
     })
-
-    const NON_SAMPLED_ATTRIBUTE_NAME = 'non_sampled';
 
     class TestAttributeSamplingSampler implements Sampler {
 

--- a/test/trace/samplers/coralogix-transaction-sampler.spec.ts
+++ b/test/trace/samplers/coralogix-transaction-sampler.spec.ts
@@ -5,13 +5,19 @@ import {Attributes, Context, createTraceState, Link, ROOT_CONTEXT, SpanKind, Tra
 import assert from "node:assert"
 import {
     BasicTracerProvider,
+    ReadableSpan,
     Sampler,
     SamplingDecision,
     SamplingResult,
-    Span,
 } from "@opentelemetry/sdk-trace-base";
 import {CoralogixAttributes} from "../../../src/trace/common";
 import {isMatch} from 'lodash';
+
+// OTel 2.x no longer exports a concrete `Span` class to `instanceof` against, and the api `Span`
+// type does not expose `.attributes`. Recording spans returned by the SDK implement `ReadableSpan`,
+// so we read their recorded attributes through that type.
+const attributesOf = (span: opentelemetry.Span): ReadableSpan['attributes'] =>
+    (span as unknown as ReadableSpan).attributes;
 
 export default describe('CoralogixTransactionSampler', () => {
     let context: Context = ROOT_CONTEXT;
@@ -96,17 +102,17 @@ export default describe('CoralogixTransactionSampler', () => {
             const span3 = tracer.startSpan('three', {}, context);
             context = opentelemetry.trace.setSpan(context, span3);
 
-            if (span1 instanceof Span && span2 instanceof Span && span3 instanceof Span) {
-                assert.strictEqual(span1.attributes[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+            if (span1.isRecording() && span2.isRecording() && span3.isRecording()) {
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
                     'span1 must created a transaction attribute');
-                assert.strictEqual(span1.attributes[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
                     'span2 must have transaction attribute from parent');
-                assert.strictEqual(span3.attributes[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
                     'span3 must have transaction attribute from parent');
             } else {
-                assert.ok(span1 instanceof Span, 'span1 must be instance of Span');
-                assert.ok(span2 instanceof Span, 'span2 must be instance of Span');
-                assert.ok(span3 instanceof Span, 'span3 must be instance of Span');
+                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
+                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
+                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
             }
             span3.end();
             span2.end();
@@ -126,13 +132,13 @@ export default describe('CoralogixTransactionSampler', () => {
             const span3 = tracer.startSpan('three', {}, context);
             context = opentelemetry.trace.setSpan(context, span3);
 
-            if (!span1.isRecording() && !span2.isRecording() && span3 instanceof Span) {
-                assert.strictEqual(span3.attributes[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+            if (!span1.isRecording() && !span2.isRecording() && span3.isRecording()) {
+                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
                     'span3 must have transaction attribute from parent');
             } else {
                 assert.ok(!span1.isRecording(), 'span1 must no be recording');
                 assert.ok(!span2.isRecording(), 'span2 must no be recording');
-                assert.ok(span3 instanceof Span, 'span3 must be instance of Span');
+                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
             }
             span3.end();
             span2.end();
@@ -155,20 +161,20 @@ export default describe('CoralogixTransactionSampler', () => {
             const span4 = tracer.startSpan('four', {}, context);
             context = opentelemetry.trace.setSpan(context, span4);
 
-            if (span1 instanceof Span && span2 instanceof Span && span3 instanceof Span && span4 instanceof Span) {
-                assert.strictEqual(span1.attributes[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+            if (span1.isRecording() && span2.isRecording() && span3.isRecording() && span4.isRecording()) {
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
                     'span1 must created a transaction attribute');
-                assert.strictEqual(span1.attributes[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'one',
                     'span2 must have transaction attribute from parent');
-                assert.strictEqual(span3.attributes[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'three',
+                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'three',
                     'span3 must created a transaction attribute');
-                assert.strictEqual(span4.attributes[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'three',
+                assert.strictEqual(attributesOf(span4)[CoralogixAttributes.TRANSACTION_IDENTIFIER], 'three',
                     'span4 must have transaction attribute from parent');
             } else {
-                assert.ok(span1 instanceof Span, 'span1 must be instance of Span');
-                assert.ok(span2 instanceof Span, 'span2 must be instance of Span');
-                assert.ok(span3 instanceof Span, 'span3 must be instance of Span');
-                assert.ok(span4 instanceof Span, 'span4 must be instance of Span');
+                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
+                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
+                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
+                assert.ok(span4.isRecording(), 'span4 must be instance of Span');
             }
             span4.end();
             span3.end();
@@ -191,17 +197,17 @@ export default describe('CoralogixTransactionSampler', () => {
             const span3 = tracer.startSpan('three', {}, context);
             context = opentelemetry.trace.setSpan(context, span3);
 
-            if (span1 instanceof Span && span2 instanceof Span && span3 instanceof Span) {
-                assert.strictEqual(span1.attributes[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+            if (span1.isRecording() && span2.isRecording() && span3.isRecording()) {
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
                     'span1 must created a distributed transaction attribute');
-                assert.strictEqual(span1.attributes[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
                     'span2 must have distributed transaction attribute from parent');
-                assert.strictEqual(span3.attributes[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
                     'span3 must have distributed transaction attribute from parent');
             } else {
-                assert.ok(span1 instanceof Span, 'span1 must be instance of Span');
-                assert.ok(span2 instanceof Span, 'span2 must be instance of Span');
-                assert.ok(span3 instanceof Span, 'span3 must be instance of Span');
+                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
+                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
+                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
             }
             span3.end();
             span2.end();
@@ -221,13 +227,13 @@ export default describe('CoralogixTransactionSampler', () => {
             const span3 = tracer.startSpan('three', {}, context);
             context = opentelemetry.trace.setSpan(context, span3);
 
-            if (!span1.isRecording() && !span2.isRecording() && span3 instanceof Span) {
-                assert.strictEqual(span3.attributes[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+            if (!span1.isRecording() && !span2.isRecording() && span3.isRecording()) {
+                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
                     'span3 must have distributed transaction attribute from parent');
             } else {
                 assert.ok(!span1.isRecording(), 'span1 must no be recording');
                 assert.ok(!span2.isRecording(), 'span2 must no be recording');
-                assert.ok(span3 instanceof Span, 'span3 must be instance of Span');
+                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
             }
             span3.end();
             span2.end();
@@ -251,20 +257,20 @@ export default describe('CoralogixTransactionSampler', () => {
             const span4 = tracer.startSpan('four', {}, context);
             context = opentelemetry.trace.setSpan(context, span4);
 
-            if (span1 instanceof Span && span2 instanceof Span && span3 instanceof Span && span4 instanceof Span) {
-                assert.strictEqual(span1.attributes[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+            if (span1.isRecording() && span2.isRecording() && span3.isRecording() && span4.isRecording()) {
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
                     'span1 must created a transaction attribute');
-                assert.strictEqual(span1.attributes[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
                     'span2 must have distributed transaction attribute from parent');
-                assert.strictEqual(span3.attributes[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
                     'span2 must have distributed transaction attribute from parent');
-                assert.strictEqual(span4.attributes[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
+                assert.strictEqual(attributesOf(span4)[CoralogixAttributes.DISTRIBUTED_TRANSACTION_IDENTIFIER], 'one',
                     'span4 must have distributed transaction attribute from parent');
             } else {
-                assert.ok(span1 instanceof Span, 'span1 must be instance of Span');
-                assert.ok(span2 instanceof Span, 'span2 must be instance of Span');
-                assert.ok(span3 instanceof Span, 'span3 must be instance of Span');
-                assert.ok(span4 instanceof Span, 'span4 must be instance of Span');
+                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
+                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
+                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
+                assert.ok(span4.isRecording(), 'span4 must be instance of Span');
             }
             span4.end();
             span3.end();
@@ -287,17 +293,17 @@ export default describe('CoralogixTransactionSampler', () => {
             const span3 = tracer.startSpan('three', {}, context);
             context = opentelemetry.trace.setSpan(context, span3);
 
-            if (span1 instanceof Span && span2 instanceof Span && span3 instanceof Span) {
-                assert.strictEqual(span1.attributes[CoralogixAttributes.TRANSACTION_ROOT], true,
+            if (span1.isRecording() && span2.isRecording() && span3.isRecording()) {
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_ROOT], true,
                     'span1 must have transaction root');
-                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in span2.attributes),
+                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in attributesOf(span2)),
                     'span2 must not have transaction root');
-                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in span3.attributes),
+                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in attributesOf(span3)),
                     'span3 must not have transaction root');
             } else {
-                assert.ok(span1 instanceof Span, 'span1 must be instance of Span');
-                assert.ok(span2 instanceof Span, 'span2 must be instance of Span');
-                assert.ok(span3 instanceof Span, 'span3 must be instance of Span');
+                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
+                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
+                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
             }
             span3.end();
             span2.end();
@@ -320,20 +326,20 @@ export default describe('CoralogixTransactionSampler', () => {
             const span4 = tracer.startSpan('four', {}, context);
             context = opentelemetry.trace.setSpan(context, span4);
 
-            if (span1 instanceof Span && span2 instanceof Span && span3 instanceof Span && span4 instanceof Span) {
-                assert.strictEqual(span1.attributes[CoralogixAttributes.TRANSACTION_ROOT], true,
+            if (span1.isRecording() && span2.isRecording() && span3.isRecording() && span4.isRecording()) {
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_ROOT], true,
                     'span1 must have transaction root');
-                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in span2.attributes),
+                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in attributesOf(span2)),
                     'span2 must not have transaction root');
-                assert.strictEqual(span3.attributes[CoralogixAttributes.TRANSACTION_ROOT], true,
+                assert.strictEqual(attributesOf(span3)[CoralogixAttributes.TRANSACTION_ROOT], true,
                     'span3 must have transaction root');
-                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in span4.attributes),
+                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in attributesOf(span4)),
                     'span4 must not have transaction root');
             } else {
-                assert.ok(span1 instanceof Span, 'span1 must be instance of Span');
-                assert.ok(span2 instanceof Span, 'span2 must be instance of Span');
-                assert.ok(span3 instanceof Span, 'span3 must be instance of Span');
-                assert.ok(span4 instanceof Span, 'span4 must be instance of Span');
+                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
+                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
+                assert.ok(span3.isRecording(), 'span3 must be instance of Span');
+                assert.ok(span4.isRecording(), 'span4 must be instance of Span');
             }
             span4.end();
             span3.end();
@@ -352,14 +358,14 @@ export default describe('CoralogixTransactionSampler', () => {
             const span2 = tracer.startSpan('one', {}, context);
             context = opentelemetry.trace.setSpan(context, span2);
 
-            if (span1 instanceof Span && span2 instanceof Span) {
-                assert.strictEqual(span1.attributes[CoralogixAttributes.TRANSACTION_ROOT], true,
+            if (span1.isRecording() && span2.isRecording()) {
+                assert.strictEqual(attributesOf(span1)[CoralogixAttributes.TRANSACTION_ROOT], true,
                     'span1 must have transaction root');
-                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in span2.attributes),
+                assert.ok(!(CoralogixAttributes.TRANSACTION_ROOT in attributesOf(span2)),
                     'span1 must not have transaction root');
             } else {
-                assert.ok(span1 instanceof Span, 'span1 must be instance of Span');
-                assert.ok(span2 instanceof Span, 'span2 must be instance of Span');
+                assert.ok(span1.isRecording(), 'span1 must be instance of Span');
+                assert.ok(span2.isRecording(), 'span2 must be instance of Span');
             }
             span2.end();
             span1.end();

--- a/test/trace/samplers/set-express-app.spec.ts
+++ b/test/trace/samplers/set-express-app.spec.ts
@@ -1,18 +1,24 @@
 import {describe, it} from "node:test";
 import assert from "node:assert";
-import {SpanKind, ROOT_CONTEXT} from "@opentelemetry/api";
-import {SEMATTRS_HTTP_TARGET} from "@opentelemetry/semantic-conventions";
+import {Attributes, SpanKind, ROOT_CONTEXT} from "@opentelemetry/api";
+import {ATTR_URL_PATH} from "@opentelemetry/semantic-conventions";
 import {CoralogixTransactionSampler} from "../../../src/trace/samplers";
 import {CoralogixAttributes} from "../../../src/trace/common";
 
 const TRANSACTION = CoralogixAttributes.TRANSACTION_IDENTIFIER;
+// Legacy pre-stability HTTP attribute, still emitted by instrumentations that have not opted into
+// stable HTTP semconv. Kept here as a literal so the test does not depend on a deprecated export.
+const ATTR_HTTP_TARGET_LEGACY = "http.target";
 
-function resolveTransaction(sampler: CoralogixTransactionSampler, target: string): unknown {
-    const result = sampler.shouldSample(ROOT_CONTEXT, 'trace-id', 'GET', SpanKind.SERVER, {
-        [SEMATTRS_HTTP_TARGET]: target,
-    }, []);
+function resolveTransaction(sampler: CoralogixTransactionSampler, attributes: Attributes): unknown {
+    const result = sampler.shouldSample(ROOT_CONTEXT, 'trace-id', 'GET', SpanKind.SERVER, attributes, []);
     return result.attributes?.[TRANSACTION];
 }
+
+// Stable HTTP semconv: the path arrives under `url.path` without a query string.
+const urlPath = (path: string): Attributes => ({[ATTR_URL_PATH]: path});
+// Legacy semconv: the path arrives under `http.target`, query string included.
+const httpTarget = (target: string): Attributes => ({[ATTR_HTTP_TARGET_LEGACY]: target});
 
 function express4App() {
     const routeLayer = {
@@ -39,7 +45,7 @@ export default describe('CoralogixTransactionSampler#setExpressApp', () => {
         const sampler = new CoralogixTransactionSampler();
         sampler.setExpressApp(express4App() as never);
 
-        assert.strictEqual(resolveTransaction(sampler, '/users/123'), 'GET /users/:id');
+        assert.strictEqual(resolveTransaction(sampler, httpTarget('/users/123')), 'GET /users/:id');
     });
 
     it('does not throw when Express 5 has no _router', () => {
@@ -52,20 +58,37 @@ export default describe('CoralogixTransactionSampler#setExpressApp', () => {
         const sampler = new CoralogixTransactionSampler();
         sampler.setExpressApp(express5App() as never);
 
-        assert.strictEqual(resolveTransaction(sampler, '/users/123'), 'GET /users/:id');
+        assert.strictEqual(resolveTransaction(sampler, httpTarget('/users/123')), 'GET /users/:id');
     });
 
-    it('resolves the route template when the target carries a query string', () => {
+    it('resolves the route template from the legacy http.target with a query string', () => {
         const sampler = new CoralogixTransactionSampler();
         sampler.setExpressApp(express5App() as never);
 
-        assert.strictEqual(resolveTransaction(sampler, '/users/123?expand=true'), 'GET /users/:id');
+        assert.strictEqual(resolveTransaction(sampler, httpTarget('/users/123?expand=true')), 'GET /users/:id');
+    });
+
+    it('resolves the route template from the stable url.path attribute', () => {
+        const sampler = new CoralogixTransactionSampler();
+        sampler.setExpressApp(express5App() as never);
+
+        assert.strictEqual(resolveTransaction(sampler, urlPath('/users/123')), 'GET /users/:id');
+    });
+
+    it('prefers url.path over http.target when both are present (dup mode)', () => {
+        const sampler = new CoralogixTransactionSampler();
+        sampler.setExpressApp(express5App() as never);
+
+        assert.strictEqual(resolveTransaction(sampler, {
+            [ATTR_URL_PATH]: '/users/123',
+            [ATTR_HTTP_TARGET_LEGACY]: '/unknown/path',
+        }), 'GET /users/:id');
     });
 
     it('falls back to the span name when no route matches', () => {
         const sampler = new CoralogixTransactionSampler();
         sampler.setExpressApp(express5App() as never);
 
-        assert.strictEqual(resolveTransaction(sampler, '/unknown/path'), 'GET');
+        assert.strictEqual(resolveTransaction(sampler, urlPath('/unknown/path')), 'GET');
     });
 });


### PR DESCRIPTION
## Summary

Migrates the route-resolution logic in `CoralogixTransactionSampler` from the deprecated `http.target` attribute to the stable `url.path` (`ATTR_URL_PATH`), with a fallback to legacy `http.target` for backward compatibility.

`http.target` was removed from the **stable** `@opentelemetry/semantic-conventions` entry point (it now lives only in `/incubating`). Whether an instrumentation emits `http.target` (legacy) or `url.path` (stable) is decided at runtime by `OTEL_SEMCONV_STABILITY_OPT_IN`. Reading both keys makes route-template transaction naming correct in **all** modes — old, stable, and dup — and removes the dependency on a deprecated export.

> Note: this is a semconv-deprecation cleanup, **independent of the `@opentelemetry/core` vulnerability fix**. It is stacked on `chore/bump-otel-sdk-trace-base-2x` (PR #32) only to share the updated test infra; merge that first.

## Change

```ts
// before
const httpTarget = attributes?.[SEMATTRS_HTTP_TARGET]?.toString();
// after
const httpTarget = (attributes?.[ATTR_URL_PATH] ?? attributes?.[ATTR_HTTP_TARGET_LEGACY])?.toString();
```

The sampler already strips the query string (`path.replace(/[?#].*$/, '')`), so `url.path` (path only) is equivalent to `http.target` (path + query) for matching.

## Why it's low risk

- **Additive, not replacing:** still reads `http.target`, so services on the default (legacy) instrumentation config are unaffected.
- Works in every `OTEL_SEMCONV_STABILITY_OPT_IN` mode.
- No public API change.

## Validation

- `npm test` (`tsc && eslint && node --test`) — **21/21** pass (added tests for `url.path`, legacy `http.target`, and dup mode).
- `npm run build` — passes.

## Release note

Stacked on the `0.2.0` branch, so no separate version bump here. If PR #32 is released as `0.2.0` before this merges, this should ship as `0.2.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)