### PR TITLE
fix: restore Express 4 boot regression + move OTel to peerDependencies (0.3.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@coralogix/opentelemetry",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coralogix/opentelemetry",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
-        "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/sdk-trace-base": "^2.8.0",
         "@opentelemetry/semantic-conventions": "^1.25.1"
       },
       "devDependencies": {
+        "@opentelemetry/api": "^1.7.0",
+        "@opentelemetry/sdk-trace-base": "^2.8.0",
         "@types/express": "^4.17.21",
         "@types/lodash": "^4.14.201",
         "@types/node": "^20.8.8",
@@ -24,6 +24,10 @@
         "tsup": "^7.2.0",
         "tsx": "^4.16.2",
         "typescript": "^5.2.2"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0",
+        "@opentelemetry/sdk-trace-base": "^2.8.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -581,6 +585,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.7.0.tgz",
       "integrity": "sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==",
+      "dev": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -589,6 +594,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
       "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -604,6 +610,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
       "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.8.0",
@@ -620,6 +627,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
       "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralogix/opentelemetry",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -19,11 +19,15 @@
     "build": "tsup src/index.ts --format cjs,esm --clean --sourcemap --dts"
   },
   "dependencies": {
-    "@opentelemetry/api": "^1.7.0",
-    "@opentelemetry/sdk-trace-base": "^2.8.0",
     "@opentelemetry/semantic-conventions": "^1.25.1"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.7.0",
+    "@opentelemetry/sdk-trace-base": "^2.8.0"
+  },
   "devDependencies": {
+    "@opentelemetry/api": "^1.7.0",
+    "@opentelemetry/sdk-trace-base": "^2.8.0",
     "@types/express": "^4.17.21",
     "@types/lodash": "^4.14.201",
     "@types/node": "^20.8.8",

--- a/src/trace/samplers/coralogix-transaction-sampler.ts
+++ b/src/trace/samplers/coralogix-transaction-sampler.ts
@@ -81,8 +81,11 @@ export class CoralogixTransactionSampler implements Sampler {
         const routes: RouteMapping[] = [];
 
         // @types/express v4 types app.router as a deprecated string; cast to reach both v4/v5 shapes.
+        // Read `_router` first: on Express 4 it holds the router stack, while `app.router`
+        // is a getter that THROWS ("'app.router' is deprecated!"). On Express 5 `_router`
+        // is undefined, so we fall back to the public `app.router` getter.
         const compat = app as unknown as { router?: RouterLike; _router?: RouterLike };
-        const expressRouter = compat.router ?? compat._router;
+        const expressRouter = compat._router ?? compat.router;
         if (!expressRouter?.stack) {
             diag.warn('CoralogixTransactionSampler.setExpressApp: could not find the Express router stack, route templates will not be resolved');
             return;

--- a/test/trace/samplers/set-express-app.spec.ts
+++ b/test/trace/samplers/set-express-app.spec.ts
@@ -29,6 +29,22 @@ function express4App() {
     return {_router: {stack: [routeLayer]}};
 }
 
+// Real Express 4 exposes `app.router` as a getter that throws
+// ("'app.router' is deprecated!"); only `app._router` is safe to read.
+function express4AppWithDeprecatedRouterGetter() {
+    const routeLayer = {
+        name: 'bound dispatch',
+        route: {path: '/users/:id'},
+        regexp: /^\/users\/(?:([^/]+?))\/?$/i,
+    };
+    return {
+        get router(): never {
+            throw new Error("'app.router' is deprecated!");
+        },
+        _router: {stack: [routeLayer]},
+    };
+}
+
 function express5App() {
     const routeLayer = {
         name: 'bound dispatch',
@@ -45,6 +61,14 @@ export default describe('CoralogixTransactionSampler#setExpressApp', () => {
         const sampler = new CoralogixTransactionSampler();
         sampler.setExpressApp(express4App() as never);
 
+        assert.strictEqual(resolveTransaction(sampler, httpTarget('/users/123')), 'GET /users/:id');
+    });
+
+    it('does not throw on Express 4 where app.router is a deprecated throwing getter (regression)', () => {
+        const sampler = new CoralogixTransactionSampler();
+        const app = express4AppWithDeprecatedRouterGetter();
+
+        assert.doesNotThrow(() => sampler.setExpressApp(app as never));
         assert.strictEqual(resolveTransaction(sampler, httpTarget('/users/123')), 'GET /users/:id');
     });
 

--- a/test/trace/samplers/set-express-app.spec.ts
+++ b/test/trace/samplers/set-express-app.spec.ts
@@ -78,6 +78,14 @@ export default describe('CoralogixTransactionSampler#setExpressApp', () => {
         assert.doesNotThrow(() => sampler.setExpressApp(express5App() as never));
     });
 
+    it('does not throw and registers no routes when the app exposes no router stack', () => {
+        const sampler = new CoralogixTransactionSampler();
+
+        assert.doesNotThrow(() => sampler.setExpressApp({} as never));
+        // With no routes resolved, the transaction falls back to the bare span name.
+        assert.strictEqual(resolveTransaction(sampler, urlPath('/users/123')), 'GET');
+    });
+
     it('resolves the route template on Express 5', () => {
         const sampler = new CoralogixTransactionSampler();
         sampler.setExpressApp(express5App() as never);


### PR DESCRIPTION
## Summary

Two focused fixes on top of the merged #33 (`url.path` migration, released as `0.2.1`):

1. **Restore Express 4 boot in `setExpressApp`.** PR #27 changed the router lookup to `app.router ?? app._router`. On **Express 4**, `app.router` is a getter that **throws** (`'app.router' is deprecated!`), so `setExpressApp` threw during app boot (NestJS 11 / Express 4 apps crash on startup). We now read `app._router` first (safe and populated on Express 4) and fall back to the public `app.router` getter on Express 5.
2. **Move `@opentelemetry/api` + `@opentelemetry/sdk-trace-base` to `peerDependencies`.** These packages carry global state (TracerProvider, context manager); shipping them as direct `dependencies` risked duplicate installs that break the global context for OTel v2 consumers. Kept in `devDependencies` for local build/test.

Version bumped to **`0.3.0`** (minor): the `peerDependencies` move changes the install contract.

> Note: `0.2.1` (from #33) shipped the stable-semconv `url.path` fix but **not** the Express 4 boot fix — this PR completes it.

## Changes

- `src/trace/samplers/coralogix-transaction-sampler.ts`: `_router ?? router` lookup order + comment.
- `package.json`: `peerDependencies` for `@opentelemetry/api` (`^1.7.0`) and `@opentelemetry/sdk-trace-base` (`^2.8.0`); same in `devDependencies`; version `0.3.0`.
- `test/trace/samplers/set-express-app.spec.ts`: regression test for the throwing `app.router` getter; guard test for an app exposing no router stack.

## Validation

- `npm test` (`tsc` + `eslint` + unit) — **23/23 pass**.
- `npm run build` — clean (CJS + ESM + DTS).
- `npm ci` — lockfile in sync.
- **Real end-to-end** against Express **4.22.2** and **5.2.1** with real `@opentelemetry/instrumentation-http` + `-express` and the packed `0.3.0` tarball: both boot without throwing and resolve `GET /users/:id` under **legacy and stable** (`OTEL_SEMCONV_STABILITY_OPT_IN=http`) semconv. Confirmed a single shared OTel copy (peerDeps resolve correctly, no nested duplicate).

## Consumer note

Consumers must have `@opentelemetry/api` (`^1.7.0`) and `@opentelemetry/sdk-trace-base` (`^2.8.0`) installed in their app (they already do in any OTel setup).

## Out of scope

Mounted sub-router (prefixed) transaction naming remains a pre-existing limitation, identical across Express 4/5 and legacy/stable — intentionally deferred to a future version.

Made with [Cursor](https://cursor.com)